### PR TITLE
Regex escape for location names

### DIFF
--- a/LocationBot.php
+++ b/LocationBot.php
@@ -60,7 +60,8 @@ $location = array();
 
 while ($row = $result->fetch_assoc())
 {        
-		array_push($location, "\b({$row['name']})\b");
+		$escaped_name = preg_quote($row['name']);
+		array_push($location, "\b($escaped_name)\b");
 }
 
 // Create a regular expression based on the locations array.


### PR DESCRIPTION
Added regex escaping for all location names. This assumes no location names will need to utilize regex.

This will allow location names like "[IN]" or (IN)" to work without any additional escaping.
